### PR TITLE
[vagrant-cloud post-processor] box checksums

### DIFF
--- a/docs/post-processors/vagrant-cloud.mdx
+++ b/docs/post-processors/vagrant-cloud.mdx
@@ -115,6 +115,16 @@ on Vagrant Cloud, as well as authentication and version information.
   - `Provider`: The Vagrant provider the box is for
   - `ArtifactId`: The ID of the input artifact.
 
+- `box_checksum` (string) - Optional checksum for the provider .box file.
+  The type of the checksum is specified within the checksum field as a prefix,
+  ex: "md5:{$checksum}". Valid values are:
+  - null or ""
+  - "md5:{$checksum}"
+  - "sha1:{$checksum}"
+  - "sha256:{$checksum}"
+  - "sha512:{$checksum}"
+  See https://www.vagrantup.com/vagrant-cloud/api#arguments-7
+
 - `no_direct_upload` (boolean) - When `true`, upload the box artifact through
   Vagrant Cloud instead of directly to the backend storage.
 

--- a/post-processor/vagrant-cloud/post-processor.hcl2spec.go
+++ b/post-processor/vagrant-cloud/post-processor.hcl2spec.go
@@ -27,6 +27,7 @@ type FlatConfig struct {
 	InsecureSkipTLSVerify *bool             `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
 	BoxDownloadUrl        *string           `mapstructure:"box_download_url" cty:"box_download_url" hcl:"box_download_url"`
 	NoDirectUpload        *bool             `mapstructure:"no_direct_upload" cty:"no_direct_upload" hcl:"no_direct_upload"`
+	BoxChecksum           *string           `mapstructure:"box_checksum" cty:"box_checksum" hcl:"box_checksum"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -58,6 +59,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"insecure_skip_tls_verify":   &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},
 		"box_download_url":           &hcldec.AttrSpec{Name: "box_download_url", Type: cty.String, Required: false},
 		"no_direct_upload":           &hcldec.AttrSpec{Name: "no_direct_upload", Type: cty.Bool, Required: false},
+		"box_checksum":               &hcldec.AttrSpec{Name: "box_checksum", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
Support `checksum` and `checksum_type` when uploading providers.
The front-end config for this is `box_checksum` on the post-processor
which expects to be specified in the `$type:$digest` format.

Closes #31 

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>
