### PR TITLE
Wrapped two "post-processor" HCL blocks

### DIFF
--- a/docs/post-processors/vagrant.mdx
+++ b/docs/post-processors/vagrant.mdx
@@ -162,16 +162,18 @@ build {
   sources = [
     "source.null.example"
   ]
-
-  post-processor "artifice" {
-    files = ["output-virtualbox-iso/vbox-example-disk001.vmdk",
-             "output-virtualbox-iso/vbox-example.ovf"]
-  }
-
-  post-processor "vagrant" {
-    keep_input_artifact = true
-    provider_override = "virtualbox"
-  }
+  post-processors {  
+    post-processor "artifice" {
+      files = [
+        "output-virtualbox-iso/vbox-example-disk001.vmdk",
+        "output-virtualbox-iso/vbox-example.ovf"
+      ]
+    }
+    post-processor "vagrant" {
+      keep_input_artifact = true
+      provider_override   = "virtualbox"
+    }  
+  }  
 }
 ```
 


### PR DESCRIPTION
Wrapped two "post-processor" HCL blocks in a "post-processors" block **in the docs** per the discussion on your forum [here](https://discuss.hashicorp.com/t/artiface-amazon-import-no-ova-image-file-found/14298/2).
