### PR TITLE
Expose default vagrantfile template as a template variable `{{.DefaultTemplate}}`

### DIFF
--- a/.web-docs/components/builder/vagrant/README.md
+++ b/.web-docs/components/builder/vagrant/README.md
@@ -101,6 +101,8 @@ the Compress post-processor will not work with this builder.
   be found here. The template variables available to you are
   `{{ .BoxName }}`, `{{ .SyncedFolder }}`, and `{{.InsertKey}}`, which
   correspond to the Packer options box_name, synced_folder, and insert_key.
+  Alternatively, the template variable `{{.DefaultTemplate}}` is available for
+  use if you wish to extend the default generated template.
 
 - `synced_folder` (string) - Path to the folder to be synced to the guest. The path can be absolute
   or relative to the directory Packer is being run from.

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -105,6 +105,8 @@ type Config struct {
 	// be found here. The template variables available to you are
 	// `{{ .BoxName }}`, `{{ .SyncedFolder }}`, and `{{.InsertKey}}`, which
 	// correspond to the Packer options box_name, synced_folder, and insert_key.
+	// Alternatively, the template variable `{{.DefaultTemplate}}` is available for
+	// use if you wish to extend the default generated template.
 	Template string `mapstructure:"template" required:"false"`
 	// Path to the folder to be synced to the guest. The path can be absolute
 	// or relative to the directory Packer is being run from.

--- a/builder/vagrant/step_create_vagrantfile_test.go
+++ b/builder/vagrant/step_create_vagrantfile_test.go
@@ -6,6 +6,7 @@ package vagrant
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -111,6 +112,65 @@ func TestCreateFile_InsertKeyTrue(t *testing.T) {
 	config.ssh.insert_key = true
   end
   config.vm.synced_folder ".", "/vagrant", disabled: true
+end`
+	if ok := strings.Compare(actual, expected); ok != 0 {
+		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, actual)
+	}
+}
+
+func TestCreateFile_customTemplate(t *testing.T) {
+	workdir := t.TempDir()
+	vagrantfileTemplatePath := filepath.Join(workdir, "Vagrantfile.tpl")
+	f, err := os.Create(vagrantfileTemplatePath)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer f.Close()
+
+	var TEMPLATE = `{{ .DefaultTemplate }}
+Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
+  end
+end`
+
+	_, err = f.WriteString(TEMPLATE)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	testy := StepCreateVagrantfile{
+		OutputDir: "./",
+		SourceBox: "apples",
+		BoxName:   "bananas",
+		Template:  vagrantfileTemplatePath,
+	}
+	templatePath, err := testy.createVagrantfile()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(templatePath)
+	contents, err := ioutil.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	actual := string(contents)
+	expected := `Vagrant.configure("2") do |config|
+  config.vm.define "source", autostart: false do |source|
+	source.vm.box = "apples"
+	config.ssh.insert_key = false
+  end
+  config.vm.define "output" do |output|
+	output.vm.box = "bananas"
+	output.vm.box_url = "file://package.box"
+	config.ssh.insert_key = false
+  end
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+end
+Vagrant.configure("2") do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
+  end
 end`
 	if ok := strings.Compare(actual, expected); ok != 0 {
 		t.Fatalf("EXPECTED: \n%s\n\n RECEIVED: \n%s\n\n", expected, actual)

--- a/docs-partials/builder/vagrant/Config-not-required.mdx
+++ b/docs-partials/builder/vagrant/Config-not-required.mdx
@@ -48,6 +48,8 @@
   be found here. The template variables available to you are
   `{{ .BoxName }}`, `{{ .SyncedFolder }}`, and `{{.InsertKey}}`, which
   correspond to the Packer options box_name, synced_folder, and insert_key.
+  Alternatively, the template variable `{{.DefaultTemplate}}` is available for
+  use if you wish to extend the default generated template.
 
 - `synced_folder` (string) - Path to the folder to be synced to the guest. The path can be absolute
   or relative to the directory Packer is being run from.


### PR DESCRIPTION
The whole point is to pass a vagrantfile template that can extend the default template.
As a consequence, this PR also includes tests for `template` source field not tested until now.

```hcl
source "vagrant" "foo" {
  communicator         = "ssh"
  source_path          = "some/box"
  provider             = "virtualbox"
  template             = "Vagrantfile.tpl"
}
```

```ruby
# Vagrantfile.tpl
{{ .DefaultTemplate }}

Vagrant.configure("2") do |config|
  config.vm.provider "virtualbox" do |vb|
    vb.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
  end
end
```