### PR TITLE
Replace ~/ with UserHomeDir if the value of synced_folder has the prefix '~/'

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -251,6 +251,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	if b.config.SyncedFolder != "" {
+		if strings.HasPrefix(b.config.SyncedFolder, "~/") {
+			homedir, _ := os.UserHomeDir()
+			b.config.SyncedFolder = filepath.Join(homedir, b.config.SyncedFolder[2:])
+		}
 		b.config.SyncedFolder, err = filepath.Abs(b.config.SyncedFolder)
 		if err != nil {
 			errs = packersdk.MultiErrorAppend(errs,


### PR DESCRIPTION
# Description

If one sets the value of the synced_folder as `~/dir`, packer responds an error which is shown in #68.
This PR is to solve the error.

# Test Results

```
$ make test
?   	github.com/hashicorp/packer-plugin-vagrant	[no test files]
ok  	github.com/hashicorp/packer-plugin-vagrant/builder/vagrant	1.532s
ok  	github.com/hashicorp/packer-plugin-vagrant/post-processor/vagrant	1.547s
ok  	github.com/hashicorp/packer-plugin-vagrant/post-processor/vagrant-cloud	1.938s
?   	github.com/hashicorp/packer-plugin-vagrant/version	[no test files]
```

Closes https://github.com/hashicorp/packer-plugin-vagrant/issues/68