### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/docs/post-processors/vagrant-cloud.mdx
+++ b/docs/post-processors/vagrant-cloud.mdx
@@ -17,9 +17,9 @@ simple way.
 
 The Vagrant Cloud post-processor enables the upload of Vagrant boxes to Vagrant
 Cloud. Currently, the Vagrant Cloud post-processor will accept and upload boxes
-supplied to it from the [Vagrant](/docs/post-processors/vagrant) or
-[Artifice](/docs/post-processors/artifice) post-processors and the
-[Vagrant](/docs/builders/vagrant) builder.
+supplied to it from the [Vagrant](/packer/plugins/post-processors/vagrant/vagrant) or
+[Artifice](/packer/docs/post-processors/artifice) post-processors and the
+[Vagrant](/packer/plugins/builders/vagrant/vagrant) builder.
 
 You'll need to be familiar with Vagrant Cloud, have an upgraded account to
 enable box hosting, and be distributing your box via the [shorthand
@@ -108,7 +108,7 @@ on Vagrant Cloud, as well as authentication and version information.
 
 - `box_download_url` (string) - Optional URL for a self-hosted box. If this
   is set the box will not be uploaded to the Vagrant Cloud.
-  This is a [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you
+  This is a [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you
   may use user variables and template functions in this field.
   The following extra variables are also available in this engine:
 

--- a/docs/post-processors/vagrant.mdx
+++ b/docs/post-processors/vagrant.mdx
@@ -23,7 +23,7 @@ Packer to automatically create arbitrarily complex Vagrant boxes, and is in
 fact how the official boxes distributed by Vagrant are created.
 
 If you've never used a post-processor before, please read the documentation on
-[using post-processors](/docs/templates/legacy_json_templates/post-processors) in templates.
+[using post-processors](/packer/docs/templates/legacy_json_templates/post-processors) in templates.
 This knowledge will be expected for the remainder of this document.
 
 Because Vagrant boxes are
@@ -83,7 +83,7 @@ more details about certain options in following sections.
 
 - `output` (string) - The full path to the box file that will be created by
   this post-processor. This is a
-  [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you may use user
+  [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you may use user
   variables and template functions in this field. The following extra
   variables are also available in this engine:
 
@@ -102,8 +102,8 @@ more details about certain options in following sections.
   `lxc`, `scaleway`, `hyperv`, `parallels`, `aws`, or `google`.
 
 - `vagrantfile_template` (string) - Path to a template to use for the
-  Vagrantfile that is packaged with the box. This option supports the usage of the [template engine](/docs/templates/legacy_json_templates/engine)
-  for JSON and the [contextual variables](/docs/templates/hcl_templates/contextual-variables) for HCL2.
+  Vagrantfile that is packaged with the box. This option supports the usage of the [template engine](/packer/docs/templates/legacy_json_templates/engine)
+  for JSON and the [contextual variables](/packer/docs/templates/hcl_templates/contextual-variables) for HCL2.
 
 - `vagrantfile_template_generated` (boolean) - By default, Packer will
   exit with an error if the file specified using the
@@ -241,7 +241,7 @@ artifact (the raw virtual machine, for example), then you must configure Packer
 to keep it.
 
 Please see the [documentation on input
-artifacts](/docs/templates/legacy_json_templates/post-processors#input-artifacts) for more information.
+artifacts](/packer/docs/templates/legacy_json_templates/post-processors#input-artifacts) for more information.
 
 ### Docker
 


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them