### PR TITLE
fix post-processor for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 main
 dist/*
 packer-plugin-vagrant
+packer-plugin-vagrant.exe

--- a/post-processor/vagrant/libvirt.go
+++ b/post-processor/vagrant/libvirt.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
@@ -68,7 +67,7 @@ func (p *LibVirtProvider) Process(ui packersdk.Ui, artifact packersdk.Artifact, 
 
 	// Copy the disk image into the temporary directory (as box.img)
 	for _, path := range artifact.Files() {
-		if strings.HasSuffix(path, diskName) {
+		if filepath.Base(path) == diskName {
 			ui.Message(fmt.Sprintf("Copying from artifact: %s", path))
 			dstPath := filepath.Join(dir, "box.img")
 			if err = CopyContents(dstPath, path); err != nil {

--- a/post-processor/vagrant/libvirt.go
+++ b/post-processor/vagrant/libvirt.go
@@ -68,7 +68,7 @@ func (p *LibVirtProvider) Process(ui packersdk.Ui, artifact packersdk.Artifact, 
 
 	// Copy the disk image into the temporary directory (as box.img)
 	for _, path := range artifact.Files() {
-		if strings.HasSuffix(path, "/"+diskName) {
+		if strings.HasSuffix(path, diskName) {
 			ui.Message(fmt.Sprintf("Copying from artifact: %s", path))
 			dstPath := filepath.Join(dir, "box.img")
 			if err = CopyContents(dstPath, path); err != nil {


### PR DESCRIPTION
I'm building a ubuntu 22.04 vagrant box for libvirt provider. The packer config is the one from https://github.com/lavabit/robox/blob/master/generic-libvirt.json. 

This works fine when building on a linux host (which is probably the most common case). However, when building on a windows host this plugin fails to include the qcow2 image (renamed to box.img) in the box. I'm using [Stefan Weil's QEMU for Windows distribution](https://qemu.weilnetz.de/w64/), which is rather slow, but it does produce a valid qcow2 image. 

I've traced this down to be a problem with "/" that actually is a "\\" when doing the build on windows.
My fix is rather optimistic and simply removes the slash for the suffix test. 

I'm using packer v1.8.5
