### PR TITLE
.gitignore: ignore .docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ main
 dist/*
 packer-plugin-vagrant
 packer-plugin-vagrant.exe
+.docs


### PR DESCRIPTION
The .docs directory is generated, and should therefore not be tracked by Git.