### PR TITLE
docs: fixed dead links and improved Markdown formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,8 +8,8 @@ Issues on GitHub are intended to be related to bugs or feature requests, so we
 recommend using our other community resources instead of asking here if you
 have a question.
 
-- Packer Guides: https://www.packer.io/guides
-- Discussion List: https://groups.google.com/group/packer-tool
+- Packer Guides: <https://developer.hashicorp.com/packer/guides>
+- Discussion List: <https://groups.google.com/g/packer-tool>
 - Any other questions can be sent to the packer section of the HashiCorp
-  forum: https://discuss.hashicorp.com/c/packer
-- Packer community links: https://www.packer.io/community
+  forum: <https://discuss.hashicorp.com/c/packer>
+- Packer community links: <https://www.packer.io/community>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Packer Plugin Vagrant
+
 The `Vagrant` multi-component plugin can be used with HashiCorp [Packer](https://www.packer.io)
 to create custom images. For the full list of available features for this plugin see [docs](docs).
 
@@ -10,10 +11,10 @@ to create custom images. For the full list of available features for this plugin
 
 Starting from version 1.7, Packer supports a new `packer init` command allowing
 automatic installation of Packer plugins. Read the
-[Packer documentation](https://www.packer.io/docs/commands/init) for more information.
+[Packer documentation](https://developer.hashicorp.com/packer/docs/commands/init) for more information.
 
-To install this plugin, copy and paste this code into your Packer configuration .
-Then, run [`packer init`](https://www.packer.io/docs/commands/init).
+To install this plugin, copy and paste this code into your Packer configuration.
+Then, run [`packer init`](https://developer.hashicorp.com/packer/docs/commands/init).
 
 ```hcl
 packer {
@@ -26,15 +27,13 @@ packer {
 }
 ```
 
-
 #### Manual installation
 
 You can find pre-built binary releases of the plugin [here](https://github.com/hashicorp/packer-plugin-vagrant/releases).
 Once you have downloaded the latest archive corresponding to your target OS,
 uncompress it to retrieve the plugin binary file corresponding to your platform.
 To install the plugin, please follow the Packer documentation on
-[installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
+[installing a plugin](https://developer.hashicorp.com/packer/docs/plugins/install-plugins).
 
 ### From Sources
 
@@ -43,14 +42,12 @@ locally and run the command `go build` from the root
 directory. Upon successful compilation, a `packer-plugin-vagrant` plugin
 binary file can be found in the root directory.
 To install the compiled plugin, please follow the official Packer documentation
-on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installing-plugins).
-
+on [installing a plugin](https://developer.hashicorp.com/packer/docs/plugins/install-plugins).
 
 ### Configuration
 
 For more information on how to configure the plugin, please read the
 documentation located in the [`docs/`](docs) directory.
-
 
 ## Contributing
 

--- a/docs-partials/builder/vagrant/Config-not-required.mdx
+++ b/docs-partials/builder/vagrant/Config-not-required.mdx
@@ -86,7 +86,7 @@
 - `output_vagrantfile` (string) - Output Vagrantfile
 
 - `package_include` ([]string) - Equivalent to setting the
-  [`--include`](https://www.vagrantup.com/docs/cli/package.html#include-x-y-z) option
+  [`--include`](https://developer.hashicorp.com/vagrant/docs/cli/package#include-x-y-z) option
   in `vagrant package`; defaults to unset
 
 <!-- End of code generated from the comments of the Config struct in builder/vagrant/builder.go; -->

--- a/docs-partials/builder/vagrant/Config-required.mdx
+++ b/docs-partials/builder/vagrant/Config-required.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the Config struct in builder/vagrant/builder.go; DO NOT EDIT MANUALLY -->
 
 - `source_path` (string) - URL of the vagrant box to use, or the name of the vagrant box.
-  hashicorp/precise64, ./mylocalbox.box and https://example.com/my-box.box
+  hashicorp/precise64, ./mylocalbox.box and <https://example.com/my-box.box>
   are all valid source boxes. If your source is a .box file, whether
   locally or from a URL like the latter example above, you will also need
   to provide a box_name. This option is required, unless you set

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 The Vagrant plugin integrates Packer with HashiCorp [Vagrant](https://www.vagrantup.com/), allowing you to use Packer to create development boxes.
 
-- [builder](/docs/builders/vagrant.mdx) - The Vagrant builder is intended for building new boxes from already-existing boxes.
+- [vagrant builder](/docs/builders/vagrant.mdx) - The Vagrant builder is intended for building new boxes from already-existing boxes.
 
-- [post-processor](/docs/post-processors/vagrant.mdx) - The Packer Vagrant post-processor takes a build and converts the artifact into a valid Vagrant box.
+- [vagrant post-processor](/docs/post-processors/vagrant.mdx) - The Packer Vagrant post-processor takes a build and converts the artifact into a valid Vagrant box.
+
+- [vagrant-cloud post-processor](/docs/post-processors/vagrant-cloud.mdx) - The Vagrant Cloud post-processor enables the upload of Vagrant boxes to Vagrant Cloud.

--- a/docs/builders/vagrant.mdx
+++ b/docs/builders/vagrant.mdx
@@ -33,14 +33,14 @@ rather than initializing a new Vagrant workspace, you use an already defined
 one, by using `global_id` instead of `source_box`.
 
 Please note that if you are using the Vagrant builder, then the Vagrant
-post-processor is unnecesary because the output of the Vagrant builder is
+post-processor is unnecessary because the output of the Vagrant builder is
 already a Vagrant box; using that post-processor with the Vagrant builder will
 cause your build to fail. Similarly, since Vagrant boxes are already compressed,
 the Compress post-processor will not work with this builder.
 
 ## Configuration Reference
 
-### Required:
+### Required
 
 - `source_path` (string) - URL of the vagrant box to use, or the name of the
   vagrant box. `hashicorp/precise64`, `./mylocalbox.box` and
@@ -59,7 +59,7 @@ the Compress post-processor will not work with this builder.
   `source_box`, Packer will skip the Vagrant initialize and add steps, and
   simply launch the box directly using the global id.
 
-### Optional:
+### Optional
 
 @include 'builder/vagrant/Config-not-required.mdx'
 

--- a/docs/post-processors/vagrant-cloud.mdx
+++ b/docs/post-processors/vagrant-cloud.mdx
@@ -17,13 +17,12 @@ simple way.
 
 The Vagrant Cloud post-processor enables the upload of Vagrant boxes to Vagrant
 Cloud. Currently, the Vagrant Cloud post-processor will accept and upload boxes
-supplied to it from the [Vagrant](/packer/plugins/post-processors/vagrant/vagrant) or
-[Artifice](/packer/docs/post-processors/artifice) post-processors and the
-[Vagrant](/packer/plugins/builders/vagrant/vagrant) builder.
+supplied to it from the [Vagrant](/docs/post-processors/vagrant.mdx) or
+[Artifice](https://developer.hashicorp.com/packer/docs/post-processors/artifice) post-processors and the
+[Vagrant](/docs/builders/vagrant.mdx) builder.
 
 You'll need to be familiar with Vagrant Cloud, have an upgraded account to
-enable box hosting, and be distributing your box via the [shorthand
-name](https://docs.vagrantup.com/v2/cli/box.html) configuration.
+enable box hosting, and be distributing your box via the [shorthand name](https://docs.vagrantup.com/v2/cli/box.html) configuration.
 
 ## Workflow
 
@@ -36,21 +35,21 @@ and deliver them to your team in some fashion.
 
 Here is an example workflow:
 
-1.  You use Packer to build a Vagrant Box for the `virtualbox` provider
-2.  The `vagrant-cloud` post-processor is configured to point to the box
+1. You use Packer to build a Vagrant Box for the `virtualbox` provider
+2. The `vagrant-cloud` post-processor is configured to point to the box
     `hashicorp/foobar` on Vagrant Cloud via the `box_tag` configuration
-3.  The post-processor receives the box from the `vagrant` post-processor
-4.  It then creates the configured version, or verifies the existence of it, on
+3. The post-processor receives the box from the `vagrant` post-processor
+4. It then creates the configured version, or verifies the existence of it, on
     Vagrant Cloud
-5.  A provider matching the name of the Vagrant provider is then created
-6.  The box is uploaded to Vagrant Cloud
-7.  The upload is verified
-8.  The version is released and available to users of the box
+5. A provider matching the name of the Vagrant provider is then created
+6. The box is uploaded to Vagrant Cloud
+7. The upload is verified
+8. The version is released and available to users of the box
 
 ~> The Vagrant Cloud box (`hashicorp/foobar` in this example) must already
 exist. Packer will not create the box automatically. If running Packer in
 automation, consider using the
-[Vagrant Cloud API](https://www.vagrantup.com/docs/vagrant-cloud/api.html)
+[Vagrant Cloud API](https://www.vagrantup.com/docs/vagrant-cloud/api)
 to create the Vagrant Cloud box if it doesn't already exist.
 
 ## Configuration
@@ -58,7 +57,7 @@ to create the Vagrant Cloud box if it doesn't already exist.
 The configuration allows you to specify the target box that you have access to
 on Vagrant Cloud, as well as authentication and version information.
 
-### Required:
+### Required
 
 - `box_tag` (string) - The shorthand tag for your box that maps to Vagrant
   Cloud, for example `hashicorp/precise64`, which is short for
@@ -87,7 +86,7 @@ on Vagrant Cloud, as well as authentication and version information.
   other than the default then `access_token` can be left blank and no
   `Authorization` header will be added to requests sent by this post-processor.
 
-### Optional:
+### Optional
 
 - `no_release` (string) - If set to true, does not release the version on
   Vagrant Cloud, making it active. You can manually release the version via
@@ -106,10 +105,10 @@ on Vagrant Cloud, as well as authentication and version information.
   full-length and in-depth description of the version, typically for denoting
   changes introduced
 
-- `box_download_url` (string) - Optional URL for a self-hosted box. If this
-  is set the box will not be uploaded to the Vagrant Cloud.
-  This is a [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you
-  may use user variables and template functions in this field.
+- `box_download_url` (string) - Optional URL for a self-hosted box.
+  If this is set the box will not be uploaded to the Vagrant Cloud.
+  This is a [template engine](https://developer.hashicorp.com/packer/docs/templates/legacy_json_templates/engine).
+  Therefore, you may use user variables and template functions in this field.
   The following extra variables are also available in this engine:
 
   - `Provider`: The Vagrant provider the box is for
@@ -123,15 +122,15 @@ on Vagrant Cloud, as well as authentication and version information.
   - "sha1:{$checksum}"
   - "sha256:{$checksum}"
   - "sha512:{$checksum}"
-  See https://www.vagrantup.com/vagrant-cloud/api#arguments-7
+  See <https://www.vagrantup.com/vagrant-cloud/api#arguments-7>
 
 - `no_direct_upload` (boolean) - When `true`, upload the box artifact through
   Vagrant Cloud instead of directly to the backend storage.
 
 ## Use with the Vagrant Post-Processor
 
-An example configuration is shown below. Note the use of the [post-processors](https://www.packer.io/docs/templates/hcl_templates/blocks/build/post-processors)
-block that wraps both the Vagrant and Vagrant Cloud [post-processor](https://www.packer.io/docs/templates/hcl_templates/blocks/build/post-processor) blocks within the post-processor section. Chaining
+An example configuration is shown below. Note the use of the [post-processors](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/blocks/build/post-processors)
+block that wraps both the Vagrant and Vagrant Cloud [post-processor](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/blocks/build/post-processors) blocks within the post-processor section. Chaining
 the post-processors together in this way tells Packer that the artifact
 produced by the Vagrant post-processor should be passed directly to the Vagrant
 Cloud Post-Processor. It also sets the order in which the post-processors
@@ -289,5 +288,3 @@ build {
 
 </Tab>
 </Tabs>
-
-

--- a/docs/post-processors/vagrant.mdx
+++ b/docs/post-processors/vagrant.mdx
@@ -23,11 +23,11 @@ Packer to automatically create arbitrarily complex Vagrant boxes, and is in
 fact how the official boxes distributed by Vagrant are created.
 
 If you've never used a post-processor before, please read the documentation on
-[using post-processors](/packer/docs/templates/legacy_json_templates/post-processors) in templates.
+[using post-processors](https://developer.hashicorp.com/packer/docs/post-processors).
 This knowledge will be expected for the remainder of this document.
 
 Because Vagrant boxes are
-[provider-specific](https://www.vagrantup.com/docs/boxes/format), the
+[provider-specific](https://developer.hashicorp.com/vagrant/docs/boxes/format), the
 Vagrant post-processor is hardcoded to understand how to convert the artifacts
 of certain builders into proper boxes for their respective providers.
 
@@ -83,7 +83,7 @@ more details about certain options in following sections.
 
 - `output` (string) - The full path to the box file that will be created by
   this post-processor. This is a
-  [template engine](/packer/docs/templates/legacy_json_templates/engine). Therefore, you may use user
+  [template engine](https://developer.hashicorp.com/packer/docs/templates/legacy_json_templates/engine). Therefore, you may use user
   variables and template functions in this field. The following extra
   variables are also available in this engine:
 
@@ -102,8 +102,8 @@ more details about certain options in following sections.
   `lxc`, `scaleway`, `hyperv`, `parallels`, `aws`, or `google`.
 
 - `vagrantfile_template` (string) - Path to a template to use for the
-  Vagrantfile that is packaged with the box. This option supports the usage of the [template engine](/packer/docs/templates/legacy_json_templates/engine)
-  for JSON and the [contextual variables](/packer/docs/templates/hcl_templates/contextual-variables) for HCL2.
+  Vagrantfile that is packaged with the box. This option supports the usage of the [template engine](https://developer.hashicorp.com/packer/docs/templates/legacy_json_templates/engine)
+  for JSON and the [contextual variables](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/contextual-variables) for HCL2.
 
 - `vagrantfile_template_generated` (boolean) - By default, Packer will
   exit with an error if the file specified using the
@@ -240,8 +240,8 @@ want the final Vagrant box as the result. If you wish to keep the input
 artifact (the raw virtual machine, for example), then you must configure Packer
 to keep it.
 
-Please see the [documentation on input
-artifacts](/packer/docs/templates/legacy_json_templates/post-processors#input-artifacts) for more information.
+Please see the [documentation on input artifacts](https://developer.hashicorp.com/packer/docs/templates/legacy_json_templates/post-processors#input-artifacts)
+for more information.
 
 ### Docker
 


### PR DESCRIPTION
Fixed various dead links which where still pointing to the old Packer repo structure, updated documentation links to target <https://developer.hashicorp.com/> and improved Markdown formatting.