### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-vagrant
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/go-version v1.6.0

--- a/post-processor/vagrant/libvirt.go
+++ b/post-processor/vagrant/libvirt.go
@@ -20,13 +20,13 @@ func lower(c byte) byte {
 //
 // Valid units (case-insensitive):
 //
-//		B (byte)        1B
-//		K (kilobyte) 1024B
-//		M (megabyte) 1024K
-//		G (gigabyte) 1024M
-//		T (terabyte) 1024G
-//		P (petabyte) 1024T
-//		E (exabyte)  1024P
+//	B (byte)        1B
+//	K (kilobyte) 1024B
+//	M (megabyte) 1024K
+//	G (gigabyte) 1024M
+//	T (terabyte) 1024G
+//	P (petabyte) 1024T
+//	E (exabyte)  1024P
 //
 // The default is M.
 func sizeInMegabytes(size string) uint64 {


### PR DESCRIPTION
- github: remove test-plugin-example workflow
- go.mod: bump go version from 1.18 to 1.19
