### PR TITLE
Treat `201 Created` response codes as successful requests

### DIFF
--- a/post-processor/vagrant-cloud/step_create_provider.go
+++ b/post-processor/vagrant-cloud/step_create_provider.go
@@ -61,7 +61,7 @@ func (s *stepCreateProvider) Run(ctx context.Context, state multistep.StateBag) 
 
 	resp, err := client.Post(path, wrapper)
 
-	if err != nil || (resp.StatusCode != 200) {
+	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
 		cloudErrors := &VagrantCloudErrors{}
 		err = decodeBody(resp, cloudErrors)
 		if err != nil {

--- a/post-processor/vagrant-cloud/step_create_version.go
+++ b/post-processor/vagrant-cloud/step_create_version.go
@@ -43,7 +43,7 @@ func (s *stepCreateVersion) Run(ctx context.Context, state multistep.StateBag) m
 
 	resp, err := client.Post(path, wrapper)
 
-	if err != nil || (resp.StatusCode != 200) {
+	if err != nil || (resp.StatusCode != 200 && resp.StatusCode != 201) {
 		cloudErrors := &VagrantCloudErrors{}
 		err = decodeBody(resp, cloudErrors)
 		if err != nil {


### PR DESCRIPTION
The Vagrant Cloud API responds to the creation of resources with `200 OK` and the create version and create provider steps only check for this status code. However according to RESTful conventions the expected response for resource creation would be `201 Created`. From MDN[1]:

    The HTTP 201 Created success status response code indicates that the
    request has succeeded and has led to the creation of a resource

and restfulapi.net[2]:

    HTTP Status 201 indicates that as a result of HTTP POST request, one
    or more new resources have been successfully created on the server.

To ensure that the post-processor works with alternative implementations that provide Vagrant Cloud like functionality, but adhere to RESTful conventions, it would be useful if the response code checks allowed a `201` status code.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
[2] https://restfulapi.net/http-status-201-created/