### PR TITLE
Architecture support (vagrant-cloud post-processor)

### DIFF
--- a/docs/post-processors/vagrant-cloud.mdx
+++ b/docs/post-processors/vagrant-cloud.mdx
@@ -82,13 +82,20 @@ on Vagrant Cloud, as well as authentication and version information.
 
 - `vagrant_cloud_url` (string) - Override the base URL for Vagrant Cloud.
   This is useful if you're using Vagrant Private Cloud in your own network.
-  Defaults to `https://vagrantcloud.com/api/v1`. If this value is set to something
+  Defaults to `https://vagrantcloud.com/api/v2`. If this value is set to something
   other than the default then `access_token` can be left blank and no
   `Authorization` header will be added to requests sent by this post-processor.
 
 ### Optional
+- `architecture` (string) - The architecture of the Vagrant box. This will be
+  detected from the box if possible by default. Supported values: amd64, i386,
+  arm, arm64, ppc64le, ppc64, mips64le, mips64, mipsle, mips, and s390x.
 
-- `no_release` (string) - If set to true, does not release the version on
+- `default_architecture` (string) - The architecture that should be flagged as
+  the default architecture for this provider. See the [Vagrant Cloud documentation](https://developer.hashicorp.com/vagrant/vagrant-cloud/boxes/architecture)
+  for more information.
+
+- `no_release` (boolean) - If set to true, does not release the version on
   Vagrant Cloud, making it active. You can manually release the version via
   the API or Web UI. Defaults to `false`.
 
@@ -111,6 +118,7 @@ on Vagrant Cloud, as well as authentication and version information.
   Therefore, you may use user variables and template functions in this field.
   The following extra variables are also available in this engine:
 
+  - `Architecture`: The architecture of the Vagrant box
   - `Provider`: The Vagrant provider the box is for
   - `ArtifactId`: The ID of the input artifact.
 
@@ -147,6 +155,7 @@ likely cause the Vagrant Cloud post-processor to error and fail.
   "variables": {
     "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
     "version": "1.0.{{timestamp}}"
+    "architecture": "amd64",
   },
   "post-processors": [
     {
@@ -164,7 +173,8 @@ likely cause the Vagrant Cloud post-processor to error and fail.
         "type": "vagrant-cloud",
         "box_tag": "hashicorp/precise64",
         "access_token": "{{user `cloud_token`}}",
-        "version": "{{user `version`}}"
+        "version": "{{user `version`}}",
+        "architecture": "{{user `architecture`}}"
       }
     ]
   ]
@@ -190,6 +200,7 @@ build {
       access_token = "${var.cloud_token}"
       box_tag      = "hashicorp/precise64"
       version      = "${local.version}"
+      architecture = "${local.architecture}"
     }
   }
 }
@@ -242,7 +253,8 @@ Additional files bundled by the Artifice post-processor will be ignored.
         "type": "vagrant-cloud",
         "box_tag": "myorganisation/mybox",
         "access_token": "{{user `cloud_token`}}",
-        "version": "0.1.0"
+        "version": "0.1.0",
+        "architecture": "amd64"
       }
     ]
   ]
@@ -275,6 +287,7 @@ build {
       access_token = "${var.cloud_token}"
       box_tag      = "myorganisation/mybox"
       version      = "0.1.0"
+      architecture = "amd64"
     }
   }
 }

--- a/docs/post-processors/vagrant.mdx
+++ b/docs/post-processors/vagrant.mdx
@@ -38,6 +38,7 @@ providers.
 - Azure
 - DigitalOcean
 - Docker
+- File
 - Hyper-V
 - LXC
 - Parallels
@@ -64,6 +65,11 @@ However, if you want to configure things a bit more, the post-processor does
 expose some configuration options. The available options are listed below, with
 more details about certain options in following sections.
 
+- `architecture` (string) - The architecture of the Vagrant box. This will be
+  set to the detected architecture of the builder host by default. Supported
+  values: amd64, i386, arm, arm64, ppc64le, ppc64, mips64le, mips64, mipsle,
+  mips, and s390x.
+
 - `compression_level` (number) - An integer representing the compression
   level to use when creating the Vagrant box. Valid values range from 0 to 9,
   with 0 being no compression and 9 being the best compression. By default,
@@ -87,12 +93,13 @@ more details about certain options in following sections.
   variables and template functions in this field. The following extra
   variables are also available in this engine:
 
+  - `Architecture`: The architecture of the Vagrant box
   - `Provider`: The Vagrant provider the box is for
   - `ArtifactId`: The ID of the input artifact.
   - `BuildName`: The name of the build.
 
   By default, the value of this config is
-  `packer_{{.BuildName}}_{{.Provider}}.box`.
+  `packer_{{.BuildName}}_{{.Provider}}_{{.Architecture}}.box`.
 
 - `provider_override` (string) - this option will override the internal logic
   that decides which Vagrant provider to set for a particular Packer builder's
@@ -215,6 +222,7 @@ The available provider names are:
 - `aws`
 - `azure`
 - `digitalocean`
+- `file`
 - `google`
 - `hyperv`
 - `parallels`

--- a/post-processor/vagrant-cloud/post-processor.hcl2spec.go
+++ b/post-processor/vagrant-cloud/post-processor.hcl2spec.go
@@ -22,6 +22,8 @@ type FlatConfig struct {
 	Version               *string           `mapstructure:"version" cty:"version" hcl:"version"`
 	VersionDescription    *string           `mapstructure:"version_description" cty:"version_description" hcl:"version_description"`
 	NoRelease             *bool             `mapstructure:"no_release" cty:"no_release" hcl:"no_release"`
+	Architecture          *string           `mapstructure:"architecture" cty:"architecture" hcl:"architecture"`
+	DefaultArchitecture   *string           `mapstructure:"default_architecture" cty:"default_architecture" hcl:"default_architecture"`
 	AccessToken           *string           `mapstructure:"access_token" cty:"access_token" hcl:"access_token"`
 	VagrantCloudUrl       *string           `mapstructure:"vagrant_cloud_url" cty:"vagrant_cloud_url" hcl:"vagrant_cloud_url"`
 	InsecureSkipTLSVerify *bool             `mapstructure:"insecure_skip_tls_verify" cty:"insecure_skip_tls_verify" hcl:"insecure_skip_tls_verify"`
@@ -54,6 +56,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"version":                    &hcldec.AttrSpec{Name: "version", Type: cty.String, Required: false},
 		"version_description":        &hcldec.AttrSpec{Name: "version_description", Type: cty.String, Required: false},
 		"no_release":                 &hcldec.AttrSpec{Name: "no_release", Type: cty.Bool, Required: false},
+		"architecture":               &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
+		"default_architecture":       &hcldec.AttrSpec{Name: "default_architecture", Type: cty.String, Required: false},
 		"access_token":               &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"vagrant_cloud_url":          &hcldec.AttrSpec{Name: "vagrant_cloud_url", Type: cty.String, Required: false},
 		"insecure_skip_tls_verify":   &hcldec.AttrSpec{Name: "insecure_skip_tls_verify", Type: cty.Bool, Required: false},

--- a/post-processor/vagrant-cloud/step_create_provider.go
+++ b/post-processor/vagrant-cloud/step_create_provider.go
@@ -14,12 +14,14 @@ import (
 )
 
 type Provider struct {
-	Name         string `json:"name"`
-	Url          string `json:"url,omitempty"`
-	HostedToken  string `json:"hosted_token,omitempty"`
-	UploadUrl    string `json:"upload_url,omitempty"`
-	Checksum     string `json:"checksum,omitempty"`
-	ChecksumType string `json:"checksum_type,omitempty"`
+	Name                string `json:"name"`
+	Url                 string `json:"url,omitempty"`
+	HostedToken         string `json:"hosted_token,omitempty"`
+	UploadUrl           string `json:"upload_url,omitempty"`
+	Checksum            string `json:"checksum,omitempty"`
+	ChecksumType        string `json:"checksum_type,omitempty"`
+	Architecture        string `json:"architecture,omitempty"`
+	DefaultArchitecture bool   `json:"default_architecture,omitempty"`
 }
 
 type stepCreateProvider struct {
@@ -34,10 +36,16 @@ func (s *stepCreateProvider) Run(ctx context.Context, state multistep.StateBag) 
 	providerName := state.Get("providerName").(string)
 	downloadUrl := state.Get("boxDownloadUrl").(string)
 	checksum := state.Get("boxChecksum").(string)
+	architecture := state.Get("architecture").(string)
+	defaultArchitecture := state.Get("defaultArchitecture").(bool)
 
 	path := fmt.Sprintf("box/%s/version/%v/providers", box.Tag, version.Version)
 
-	provider := &Provider{Name: providerName}
+	provider := &Provider{
+		Name:                providerName,
+		Architecture:        architecture,
+		DefaultArchitecture: defaultArchitecture,
+	}
 
 	if downloadUrl != "" {
 		provider.Url = downloadUrl

--- a/post-processor/vagrant-cloud/step_prepare_upload.go
+++ b/post-processor/vagrant-cloud/step_prepare_upload.go
@@ -43,7 +43,7 @@ func (s *stepPrepareUpload) Run(ctx context.Context, state multistep.StateBag) m
 		}
 	}
 
-	path := fmt.Sprintf("box/%s/version/%v/provider/%s/upload", box.Tag, version.Version, provider.Name)
+	path := fmt.Sprintf("box/%s/version/%v/provider/%s/%s/upload", box.Tag, version.Version, provider.Name, provider.Architecture)
 	if !config.NoDirectUpload {
 		path = path + "/direct"
 	}

--- a/post-processor/vagrant/file.go
+++ b/post-processor/vagrant/file.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vagrant
+
+import (
+	"fmt"
+	"path/filepath"
+
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type FileProvider struct{}
+
+func (p *FileProvider) KeepInputArtifact() bool {
+	return false
+}
+
+func (p *FileProvider) Process(ui packersdk.Ui, artifact packersdk.Artifact, dir string) (vagrantfile string, metadata map[string]interface{}, err error) {
+	// Create the metadata
+	metadata = map[string]interface{}{"provider": "file"}
+
+	// Copy all of the original contents into the temporary directory
+	for _, path := range artifact.Files() {
+		ui.Message(fmt.Sprintf("Copying: %s", path))
+
+		dstPath := filepath.Join(dir, filepath.Base(path))
+		if err = CopyContents(dstPath, path); err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/post-processor/vagrant/file_test.go
+++ b/post-processor/vagrant/file_test.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vagrant
+
+import (
+	"testing"
+)
+
+func TestFileProvider_impl(t *testing.T) {
+	var _ Provider = new(FileProvider)
+}

--- a/post-processor/vagrant/post-processor.hcl2spec.go
+++ b/post-processor/vagrant/post-processor.hcl2spec.go
@@ -25,6 +25,7 @@ type FlatConfig struct {
 	VagrantfileTemplate          *string                `mapstructure:"vagrantfile_template" cty:"vagrantfile_template" hcl:"vagrantfile_template"`
 	VagrantfileTemplateGenerated *bool                  `mapstructure:"vagrantfile_template_generated" cty:"vagrantfile_template_generated" hcl:"vagrantfile_template_generated"`
 	ProviderOverride             *string                `mapstructure:"provider_override" cty:"provider_override" hcl:"provider_override"`
+	Architecture                 *string                `mapstructure:"architecture" cty:"architecture" hcl:"architecture"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -54,6 +55,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vagrantfile_template":           &hcldec.AttrSpec{Name: "vagrantfile_template", Type: cty.String, Required: false},
 		"vagrantfile_template_generated": &hcldec.AttrSpec{Name: "vagrantfile_template_generated", Type: cty.Bool, Required: false},
 		"provider_override":              &hcldec.AttrSpec{Name: "provider_override", Type: cty.String, Required: false},
+		"architecture":                   &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -65,6 +66,40 @@ func TestPostProcessorPrepare_compressionLevel(t *testing.T) {
 	if config.CompressionLevel != 7 {
 		t.Fatalf("bad: %#v", config.CompressionLevel)
 	}
+}
+
+func TestPostProcessorPrepare_architecture(t *testing.T) {
+	var p PostProcessor
+
+	matchingArch := runtime.GOARCH
+	if mappedArch, ok := vagrantArchMap[matchingArch]; ok {
+		matchingArch = mappedArch
+	}
+
+	// Default
+	c := testConfig()
+	delete(c, "architecture")
+	if err := p.Configure(c); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config := p.config
+	if config.Architecture != matchingArch {
+		t.Fatalf("bad: %#v", config.Architecture)
+	}
+
+	// Set
+	c = testConfig()
+	c["architecture"] = "s390x"
+	if err := p.Configure(c); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	config = p.config
+	if config.Architecture != "s390x" {
+		t.Fatalf("bad: %#v", config.Architecture)
+	}
+
 }
 
 func TestPostProcessorPrepare_outputPath(t *testing.T) {


### PR DESCRIPTION
Adds architecture support to the vagrant and the vagrant-cloud post-processors. 

### Vagrant post-processor

Introduces a new configuration option to the vagrant post-processor:

* `architecture` - string
 
This is an optional value that will automatically default to the host platform's architecture. The architecture value will be included within the `metadata.json` file of the generated box.

Also included with this changeset is support for the `file` builder. This was just done to make it easier for testing generated boxes.

### Vagrant Cloud post-processor

Updates the API calls to use Vagrant Cloud's v2 API. The `v2` API supports architecture metadata for providers and the post-processor has been updated to include architecture information. New configurations options added:

* `architecture` - string
* `default_architecture` - string

By default, the post-processor will read the architecture information from the `metadata.json` within the box. If the box metadata does not include architecture information, or the architecture needs to be overridden for some reason, it can be defined using the `architecture` configuration option.

The `default_architecture` option is used for backwards compatibility support (more information available in the [Vagrant Cloud docs](https://developer.hashicorp.com/vagrant/vagrant-cloud/boxes/architecture)). If the architecture value set in `default_architecture` matches the architecture of the box then it will be marked as the default architecture on Vagrant Cloud.

Also adjusted the vagrant-cloud post-processor test so the artifact's `IdValue` matches the defined box's provider to provide a bit more clarity on the mocked API paths.

