### PR TITLE
Post-processor export Parallels macvm

### DIFF
--- a/post-processor/vagrant/parallels.go
+++ b/post-processor/vagrant/parallels.go
@@ -41,7 +41,7 @@ func (p *ParallelsProvider) Process(ui packersdk.Ui, artifact packersdk.Artifact
 		}
 
 		tmpPath := filepath.ToSlash(path)
-		pathRe := regexp.MustCompile(`^(.+?)([^/]+\.pvm/.+?)$`)
+		pathRe := regexp.MustCompile(`^(.+?)([^/]+\.(pvm|macvm)/.+?)$`)
 		matches := pathRe.FindStringSubmatch(tmpPath)
 		var pvmPath string
 		if matches != nil {


### PR DESCRIPTION
## Reason for the change

`packer-plugin-parallels` supports building of m1 macOS virtual machines, alas, without this change the default workflow succeeds with an invalid box, not containing the VM.

## What changed
Rephrased regex pattern for vm file path including `pvm` and `macvm` in a search group.
