### PR TITLE
parallels: simplify regex for vm files

### DIFF
--- a/post-processor/vagrant/parallels.go
+++ b/post-processor/vagrant/parallels.go
@@ -43,11 +43,11 @@ func (p *ParallelsProvider) Process(ui packersdk.Ui, artifact packersdk.Artifact
 		}
 
 		tmpPath := filepath.ToSlash(path)
-		pathRe := regexp.MustCompile(`^(.+?)([^/]+\.(pvm|macvm)/.+?)$`)
-		matches := pathRe.FindStringSubmatch(tmpPath)
+		pathRe := regexp.MustCompile(`[^/]+\.(pvm|macvm)/.+$`)
+		match := pathRe.FindString(tmpPath)
 		var pvmPath string
-		if matches != nil {
-			pvmPath = filepath.FromSlash(matches[2])
+		if match != "" {
+			pvmPath = filepath.FromSlash(match)
 		} else {
 			continue // Just copy a pvm
 		}


### PR DESCRIPTION
The original regex had multiple occurrences of a `.+?` pattern, which is essentially the same as a `.*`, so we replace the former by the latter for clarity.

Additionally, since the beginning of the path does not interest us, we can ignore it from the regex, and only start matching once we have found what's interesting for us, further simplifying the expression.