### PR TITLE
Fix driver return code handling

### DIFF
--- a/.web-docs/components/builder/vagrant/README.md
+++ b/.web-docs/components/builder/vagrant/README.md
@@ -90,8 +90,6 @@ the Compress post-processor will not work with this builder.
   This parameter is required when source_path have more than one provider,
   or when using vagrant-cloud post-processor. Defaults to unset.
 
-- `vagrantfile_template` (string) - What vagrantfile to use
-
 - `teardown_method` (string) - Whether to halt, suspend, or destroy the box when the build has
   completed. Defaults to "halt"
 

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -94,8 +94,6 @@ type Config struct {
 	Provider string `mapstructure:"provider" required:"false"`
 	// Options for the "vagrant init" command
 
-	// What vagrantfile to use
-	VagrantfileTpl string `mapstructure:"vagrantfile_template"`
 	// Whether to halt, suspend, or destroy the box when the build has
 	// completed. Defaults to "halt"
 	TeardownMethod string `mapstructure:"teardown_method" required:"false"`

--- a/builder/vagrant/builder.hcl2spec.go
+++ b/builder/vagrant/builder.hcl2spec.go
@@ -92,7 +92,6 @@ type FlatConfig struct {
 	BoxName                   *string           `mapstructure:"box_name" required:"false" cty:"box_name" hcl:"box_name"`
 	InsertKey                 *bool             `mapstructure:"insert_key" required:"false" cty:"insert_key" hcl:"insert_key"`
 	Provider                  *string           `mapstructure:"provider" required:"false" cty:"provider" hcl:"provider"`
-	VagrantfileTpl            *string           `mapstructure:"vagrantfile_template" cty:"vagrantfile_template" hcl:"vagrantfile_template"`
 	TeardownMethod            *string           `mapstructure:"teardown_method" required:"false" cty:"teardown_method" hcl:"teardown_method"`
 	BoxVersion                *string           `mapstructure:"box_version" required:"false" cty:"box_version" hcl:"box_version"`
 	Template                  *string           `mapstructure:"template" required:"false" cty:"template" hcl:"template"`
@@ -203,7 +202,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"box_name":                     &hcldec.AttrSpec{Name: "box_name", Type: cty.String, Required: false},
 		"insert_key":                   &hcldec.AttrSpec{Name: "insert_key", Type: cty.Bool, Required: false},
 		"provider":                     &hcldec.AttrSpec{Name: "provider", Type: cty.String, Required: false},
-		"vagrantfile_template":         &hcldec.AttrSpec{Name: "vagrantfile_template", Type: cty.String, Required: false},
 		"teardown_method":              &hcldec.AttrSpec{Name: "teardown_method", Type: cty.String, Required: false},
 		"box_version":                  &hcldec.AttrSpec{Name: "box_version", Type: cty.String, Required: false},
 		"template":                     &hcldec.AttrSpec{Name: "template", Type: cty.String, Required: false},

--- a/builder/vagrant/driver_2_2.go
+++ b/builder/vagrant/driver_2_2.go
@@ -270,7 +270,7 @@ func (d *Vagrant_2_2_Driver) vagrantCmd(args ...string) (string, string, error) 
 		log.Printf("[vagrant driver] stdout: %s", line)
 		stdoutString += line + "\n"
 	}
-	_ = cmd.Wait()
+	err = cmd.Wait()
 
 	if _, ok := err.(*exec.ExitError); ok {
 		err = fmt.Errorf("Vagrant error: %s", stderrString)

--- a/builder/vagrant/step_add_box.go
+++ b/builder/vagrant/step_add_box.go
@@ -5,6 +5,7 @@ package vagrant
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -93,6 +94,7 @@ func (s *StepAddBox) Run(ctx context.Context, state multistep.StateBag) multiste
 	// Call vagrant using prepared arguments
 	err := driver.Add(addArgs)
 	if err != nil {
+		err = fmt.Errorf("Failed to get box, if it is already in Vagrant, try using the `skip_add` option.\n%s", err)
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}

--- a/docs-partials/builder/vagrant/Config-not-required.mdx
+++ b/docs-partials/builder/vagrant/Config-not-required.mdx
@@ -37,8 +37,6 @@
   This parameter is required when source_path have more than one provider,
   or when using vagrant-cloud post-processor. Defaults to unset.
 
-- `vagrantfile_template` (string) - What vagrantfile to use
-
 - `teardown_method` (string) - Whether to halt, suspend, or destroy the box when the build has
   completed. Defaults to "halt"
 


### PR DESCRIPTION
When executing a Vagrant command, the driver would never error, unless the call to `Start` actually errored.
This is problematic, as when there's a problem with a Vagrant command, it doesn't get forwarded to the caller, and no error might be reported.

This problem stems from a modification in commit b0c799cf599e449ff3d09, which changed how the command was invoked, as previously it used `Run()` (a combination of Start and Wait), and now it split both calls in two so the outputs of the command can be processed before sending them back.
However, that change did not account for errors in `Wait`, which is where the process actually returns an error if it ends with a non-zero error code, making all commands from `vagrant` not report their errors to the driver.

Related to: #110 
