### PR TITLE
[AUTO] Update question.md template to remove reference to Google Groups mailing list.

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,7 +9,6 @@ recommend using our other community resources instead of asking here if you
 have a question.
 
 - Packer Guides: <https://developer.hashicorp.com/packer/guides>
-- Discussion List: <https://groups.google.com/g/packer-tool>
 - Any other questions can be sent to the packer section of the HashiCorp
   forum: <https://discuss.hashicorp.com/c/packer>
 - Packer community links: <https://www.packer.io/community>

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -9,6 +9,7 @@ recommend using our other community resources instead of asking here if you
 have a question.
 
 - Packer Guides: <https://developer.hashicorp.com/packer/guides>
-- Any other questions can be sent to the packer section of the HashiCorp
+- Packer Community Tools: https://developer.hashicorp.com/packer/docs/community-tools enumerates
+  vetted community resources like examples and useful tools
+- Any other questions can be sent to the Packer section of the HashiCorp
   forum: <https://discuss.hashicorp.com/c/packer>
-- Packer community links: <https://www.packer.io/community>


### PR DESCRIPTION
Since the mailing list is not usable anymore on Google groups, we
remove the link to it in our question template.
