### PR TITLE
docs: fixed formatting and diffs from actual implementation

### DIFF
--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -80,7 +80,7 @@ type Config struct {
 	// this is not recommended since these files can be very large and
 	// corruption does happen from time to time.
 	Checksum string `mapstructure:"checksum" required:"false"`
-	// if your source_path is a boxfile that we need to add to Vagrant, this is
+	// if your "source_path" is a boxfile that we need to add to Vagrant, this is
 	// the name to give it. If left blank, will default to "packer_" plus your
 	// buildname.
 	BoxName string `mapstructure:"box_name" required:"false"`

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -42,7 +42,7 @@ type Config struct {
 	Comm communicator.Config `mapstructure:",squash"`
 	// The directory to create that will contain your output box. We always
 	// create this directory and run from inside of it to prevent Vagrant init
-	// collisions. If unset, it will be set to packer- plus your buildname.
+	// collisions. If unset, it will be set to output- plus your buildname.
 	OutputDir string `mapstructure:"output_dir" required:"false"`
 	// URL of the vagrant box to use, or the name of the vagrant box.
 	// hashicorp/precise64, ./mylocalbox.box and <https://example.com/my-box.box>

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -109,7 +109,7 @@ type Config struct {
 	// Path to the folder to be synced to the guest. The path can be absolute
 	// or relative to the directory Packer is being run from.
 	SyncedFolder string `mapstructure:"synced_folder"`
-	// Don't call "vagrant add" to add the box to your local environment; this
+	// Don't call "vagrant box add" to add the box to your local environment; this
 	// is necessary if you want to launch a box that is already added to your
 	// vagrant environment.
 	SkipAdd bool `mapstructure:"skip_add" required:"false"`

--- a/builder/vagrant/builder.go
+++ b/builder/vagrant/builder.go
@@ -56,7 +56,7 @@ type Config struct {
 	// vagrant global-status; your global_id will be a 7-digit number and
 	// letter combination that you'll find in the leftmost column of the
 	// global-status output.  If you choose to use global_id instead of
-	// source_box, Packer will skip the Vagrant initialize and add steps, and
+	// source_path, Packer will skip the Vagrant initialize and add steps, and
 	// simply launch the box directly using the global id.
 	GlobalID string `mapstructure:"global_id" required:"true"`
 	// The checksum for the .box file. The type of the checksum is specified
@@ -80,7 +80,7 @@ type Config struct {
 	// this is not recommended since these files can be very large and
 	// corruption does happen from time to time.
 	Checksum string `mapstructure:"checksum" required:"false"`
-	// if your source_box is a boxfile that we need to add to Vagrant, this is
+	// if your source_path is a boxfile that we need to add to Vagrant, this is
 	// the name to give it. If left blank, will default to "packer_" plus your
 	// buildname.
 	BoxName string `mapstructure:"box_name" required:"false"`

--- a/docs/builders/vagrant.mdx
+++ b/docs/builders/vagrant.mdx
@@ -30,7 +30,7 @@ setting the `teardown_method` option. You can change the behavior so the builder
 doesn't package it (not all provisioners support the `vagrant package` command)
 by setting the `skip package` option. You can also change the behavior so that
 rather than initializing a new Vagrant workspace, you use an already defined
-one, by using `global_id` instead of `source_box`.
+one, by using `global_id` instead of `source_path`.
 
 Please note that if you are using the Vagrant builder, then the Vagrant
 post-processor is unnecessary because the output of the Vagrant builder is
@@ -56,7 +56,7 @@ the Compress post-processor will not work with this builder.
   command `vagrant global-status`; your global_id will be a 7-digit number and
   letter combination that you'll find in the leftmost column of the
   global-status output. If you choose to use `global_id` instead of
-  `source_box`, Packer will skip the Vagrant initialize and add steps, and
+  `source_path`, Packer will skip the Vagrant initialize and add steps, and
   simply launch the box directly using the global id.
 
 ### Optional


### PR DESCRIPTION
Describe the change you are making here!
- replaced `vagrant add` with `vagrant box add` in docs, since there is no subcommands with latest packer
- fixed markdown styles
- replaced prefix of box from `packer-` to `output` in docs, since it had been modified in [implementation](https://github.com/hashicorp/packer-plugin-vagrant/blob/main/builder/vagrant/builder.go#L174)

Please include tests. We recommend looking at existing tests as an example. 

```shell
24-11-19 22:36:17 git/packer-plugin-vagrant [docs/fix-builder-vagrant] % make test
?       github.com/hashicorp/packer-plugin-vagrant      [no test files]
?       github.com/hashicorp/packer-plugin-vagrant/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vagrant/builder/vagrant      1.468s
ok      github.com/hashicorp/packer-plugin-vagrant/post-processor/hcp-vagrant-registry  2.499s
ok      github.com/hashicorp/packer-plugin-vagrant/post-processor/vagrant       2.272s
ok      github.com/hashicorp/packer-plugin-vagrant/post-processor/vagrant-cloud 2.830s
```

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:
N/A
