### PR TITLE
post-processor: add `vagrantfile_content` option

### DIFF
--- a/.web-docs/components/post-processor/vagrant/README.md
+++ b/.web-docs/components/post-processor/vagrant/README.md
@@ -105,6 +105,12 @@ more details about certain options in following sections.
   creation of the Vagrantfile at some previous point in the build.
   Defaults to `false`.
 
+- `vagrantfile_content` (string) - Content of the custom Vagrantfile that is
+  packaged with the box. This option is intended to be used with
+  [`templatefile`](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/functions/file/templatefile)
+  function in HCL templates, instead of `vagrantfile_template`.
+  `vagrantfile_content` and `vagrantfile_template` can't be set both at the same time.
+
 ## Using together with the Artifice post-processor
 
 Sometimes you may want to run several builds in a pipeline rather than running

--- a/docs/post-processors/vagrant.mdx
+++ b/docs/post-processors/vagrant.mdx
@@ -121,6 +121,12 @@ more details about certain options in following sections.
   creation of the Vagrantfile at some previous point in the build.
   Defaults to `false`.
 
+- `vagrantfile_content` (string) - Content of the custom Vagrantfile that is
+  packaged with the box. This option is intended to be used with
+  [`templatefile`](https://developer.hashicorp.com/packer/docs/templates/hcl_templates/functions/file/templatefile)
+  function in HCL templates, instead of `vagrantfile_template`.
+  `vagrantfile_content` and `vagrantfile_template` can't be set both at the same time.
+
 ## Using together with the Artifice post-processor
 
 Sometimes you may want to run several builds in a pipeline rather than running

--- a/post-processor/vagrant/post-processor.hcl2spec.go
+++ b/post-processor/vagrant/post-processor.hcl2spec.go
@@ -22,6 +22,7 @@ type FlatConfig struct {
 	Include                      []string               `mapstructure:"include" cty:"include" hcl:"include"`
 	OutputPath                   *string                `mapstructure:"output" cty:"output" hcl:"output"`
 	Override                     map[string]interface{} `cty:"override" hcl:"override"`
+	VagrantfileContent           *string                `mapstructure:"vagrantfile_content" cty:"vagrantfile_content" hcl:"vagrantfile_content"`
 	VagrantfileTemplate          *string                `mapstructure:"vagrantfile_template" cty:"vagrantfile_template" hcl:"vagrantfile_template"`
 	VagrantfileTemplateGenerated *bool                  `mapstructure:"vagrantfile_template_generated" cty:"vagrantfile_template_generated" hcl:"vagrantfile_template_generated"`
 	ProviderOverride             *string                `mapstructure:"provider_override" cty:"provider_override" hcl:"provider_override"`
@@ -52,6 +53,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"include":                        &hcldec.AttrSpec{Name: "include", Type: cty.List(cty.String), Required: false},
 		"output":                         &hcldec.AttrSpec{Name: "output", Type: cty.String, Required: false},
 		"override":                       &hcldec.AttrSpec{Name: "override", Type: cty.Map(cty.String), Required: false},
+		"vagrantfile_content":            &hcldec.AttrSpec{Name: "vagrantfile_content", Type: cty.String, Required: false},
 		"vagrantfile_template":           &hcldec.AttrSpec{Name: "vagrantfile_template", Type: cty.String, Required: false},
 		"vagrantfile_template_generated": &hcldec.AttrSpec{Name: "vagrantfile_template_generated", Type: cty.Bool, Required: false},
 		"provider_override":              &hcldec.AttrSpec{Name: "provider_override", Type: cty.String, Required: false},

--- a/post-processor/vagrant/post-processor_test.go
+++ b/post-processor/vagrant/post-processor_test.go
@@ -202,6 +202,22 @@ func TestPostProcessorPrepare_vagrantfileTemplateExists(t *testing.T) {
 	}
 }
 
+func TestPostProcessorPrepare_vagrantfileContent(t *testing.T) {
+	c := testConfig()
+	c["vagrantfile_content"] = "Vagrant.configure('2') do |config|\nend\n"
+
+	var p PostProcessor
+
+	if err := p.Configure(c); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	c["vagrantfile_template"] = "Vagrantfile"
+	if err := p.Configure(c); err == nil {
+		t.Fatal("expected error since vagrantfile_content and vagrantfile_template are both set")
+	}
+}
+
 func TestPostProcessorPrepare_ProviderOverrideExists(t *testing.T) {
 	c := testConfig()
 	c["provider_override"] = "foo"


### PR DESCRIPTION
Allow specifying custom Vagrantfile content as string - so it can be generated using `templatefile()`.

This pull request takes a slightly different approach than #112:

- `vagrantfile_content` isn't processed by old template engine

- thus it's called `vagrantfile_content` and not `vagrantfile_template_content`

- `vagrantfile_content` can't be set together with `vagrantfile_template`

Closes #104

