### PR TITLE
Fix file matching within artifact

### DIFF
--- a/post-processor/hcp-vagrant-registry/post-processor.go
+++ b/post-processor/hcp-vagrant-registry/post-processor.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -410,7 +411,7 @@ func metadataFromVagrantBox(boxfile string) (metadata map[string]interface{}, er
 			return nil, fmt.Errorf("Failed reading header info from box tar archive: %w", err)
 		}
 
-		if hdr.Name == "metadata.json" {
+		if path.Base(hdr.Name) == "metadata.json" {
 			var contents []byte
 			contents, err = io.ReadAll(tr)
 			if err != nil {

--- a/post-processor/hcp-vagrant-registry/post-processor_test.go
+++ b/post-processor/hcp-vagrant-registry/post-processor_test.go
@@ -912,6 +912,64 @@ func TestPostProcessor(t *testing.T) {
 					c["no_direct_upload"] = false
 				},
 			},
+			{
+				desc: "OK - archive paths are relative",
+				stack: []stubResponse{
+					{
+						Method:     "POST",
+						Path:       "/oauth2/token",
+						Response:   `{"access_token": "TEST_TOKEN", "expiry": 0}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "GET",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64",
+						Response:   `{}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "GET",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5",
+						Response:   `{"version": {"state": "UNRELEASED"}}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "GET",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5/provider/virtualbox",
+						Response:   `{}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "GET",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5/provider/virtualbox/architecture/amd64",
+						Response:   `{}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "PUT",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5/provider/virtualbox/architecture/amd64",
+						Response:   `{}`,
+						StatusCode: 200,
+					},
+					{
+						Method:     "GET",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5/provider/virtualbox/architecture/amd64/upload",
+						Response:   fmt.Sprintf(`{"url": "%s"}`, uploadURL),
+						StatusCode: 200,
+					},
+					{
+						Method:     "PUT",
+						Path:       "/vagrant/2022-09-30/registry/hashicorp/box/precise64/version/0.5/release",
+						Response:   `{}`,
+						StatusCode: 200,
+					},
+				},
+				files: tarFiles{
+					{"./foo.txt", "This is a foo file"},
+					{"./bar.txt", "This is a bar file"},
+					{"./metadata.json", `{"provider": "virtualbox", "architecture": "amd64"}`},
+				},
+			},
 		}
 
 		for _, tc := range testCases {


### PR DESCRIPTION
When inspecting the artifact for the metadata.json file, use the
basename value. This will remove any relative path prefix that may
exist on the file records which result in it not properly matching.
