### PR TITLE
fix: update builder id for `vmware`

### DIFF
--- a/post-processor/vagrant/post-processor.go
+++ b/post-processor/vagrant/post-processor.go
@@ -34,6 +34,7 @@ var builtins = map[string]string{
 	"mitchellh.virtualbox":                "virtualbox",
 	"mitchellh.vmware":                    "vmware",
 	"mitchellh.vmware-esx":                "vmware",
+	"vmware.desktop":                      "vmware",
 	"pearkes.digitalocean":                "digitalocean",
 	"packer.googlecompute":                "google",
 	"hashicorp.scaleway":                  "scaleway",


### PR DESCRIPTION
### Description

In `vmware/packer-plugin-vmware` v2.0.0:

- The builder ID was updated to `vmware.desktop`.
- Support for VMware ESX was removed.
- Support for VMware Workstation Player was removed.

This updates the provider identifier used by the Vagrant post-processor to use the updated `builderId` for v2.x.x+

### Resolved Issues

Refer to https://github.com/vmware/packer-plugin-vmware/issues/494.

### Rollback Plan

Revert if required.
